### PR TITLE
Support for index-specific indexing to Globus Search

### DIFF
--- a/src/dspace-api/src/globus/java/org/dspace/globus/Globus.java
+++ b/src/dspace-api/src/globus/java/org/dspace/globus/Globus.java
@@ -137,7 +137,7 @@ public class Globus
 
     public static final String CONFIG_GLOBUS_SHARE_PATH_PREFIX = "globus.share.path.prefix";
     
-    public static final String CONFIG_GLOBUS_DATASEARCH_URL = "globus.datasearch.url";
+    public static final String CONFIG_GLOBUS_SEARCH_URL = "globus.search.url";
 
     // Config properties for storage of input forms and workflows
     public static final String GLOBUS_FORMS_DIR_CONFIG_PROP = "globus.forms.dir";

--- a/src/dspace-api/src/globus/java/org/dspace/globus/GlobusSearchClient.java
+++ b/src/dspace-api/src/globus/java/org/dspace/globus/GlobusSearchClient.java
@@ -19,15 +19,24 @@ import org.json.JSONObject;
  * @author pruyne
  *
  */
-public class GlobusDataSearchClient extends GlobusClient
+public class GlobusSearchClient extends GlobusClient
 {
-    private static final Logger log = Logger.getLogger(GlobusDataSearchClient.class);
+    private static final Logger log = Logger.getLogger(GlobusSearchClient.class);
 
-    public GlobusDataSearchClient(GlobusAuthToken token, 
+    private String indexName;
+    
+    public GlobusSearchClient(GlobusAuthToken token, 
             String searchServiceUrl)
+    {
+        this(token, searchServiceUrl, null);
+    }
+    
+    public GlobusSearchClient(GlobusAuthToken token, String searchServiceUrl,
+            String indexName) 
     {
         super(token);
         setRootUrlForRequestType(RequestType.search, searchServiceUrl);
+        this.indexName = indexName;
     }
     
     public boolean index(JSONObject content, String subject, String[] visibleTo)
@@ -52,7 +61,12 @@ public class GlobusDataSearchClient extends GlobusClient
         gingest.put("ingest_data", gmeta);
 
         log.info("Indexing entry: " + gingest);
-        Object ingestReply = doPost(RequestType.search, "/ingest", 200, 
+        String ingestUrl = "/ingest";
+        if (indexName != null) {
+            ingestUrl = ingestUrl + "/" + indexName;
+        }
+        
+        Object ingestReply = doPost(RequestType.search, ingestUrl, 200, 
                 null, gingest.toString(), Object.class);
         log.info("Index of " + subject + " returned " + ingestReply);
         return ingestReply != null;

--- a/src/dspace/config/modules/globus.cfg
+++ b/src/dspace/config/modules/globus.cfg
@@ -10,7 +10,9 @@ globus.auth.url=https://auth.globus.org
 transfer.api=https://transfer.api.globusonline.org/v0.10
 group.api=https://auth.globus.org/v2/api
 identity.api=https://nexus.api.globusonline.org
-globus.datasearch.url=https://datasearch.api.demo.globus.org/v1
+# This may actually contain a list of "url$index-name" entries separated by semi-colon
+# E.g. https://search.api.globus.org/v1$index1;https://search.api.sandbox.globus.org/v1$test-index 
+globus.search.url=https://search.api.globus.org/v1$mdf
 
 # The path to the Globus Start transfer page
 transfer.url=/app/transfer


### PR DESCRIPTION
This also allows for multiple search service url, index name pairs so that
publications may be indexed to multiple indices to support testing or
redundant copies to multiple indices as desired. See globus.cfg for a summary
of how to specify server URL + index configurations.