### PR TITLE
More null errors in processing queries

### DIFF
--- a/src/dspace-api/src/globus/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/src/dspace-api/src/globus/java/org/dspace/discovery/SolrServiceImpl.java
@@ -2201,6 +2201,9 @@ public class SolrServiceImpl implements SearchService, IndexingService {
     }
 
     protected String transformDisplayedValue(Context context, String field, String value) throws SQLException {
+        if (field == null) {
+            throw new SQLException("Invalid field value for Solr Query Creation");
+        }
         if(field.equals("location.comm") || field.equals("location.coll"))
         {
             value = locationToName(context, field, value);

--- a/src/dspace-jspui/src/globus/java/org/dspace/app/webui/discovery/DiscoverUtility.java
+++ b/src/dspace-jspui/src/globus/java/org/dspace/app/webui/discovery/DiscoverUtility.java
@@ -208,9 +208,12 @@ public class DiscoverUtility
         {
             try
             {
-            String newFilterQuery = SearchUtils.getSearchService()
+            	String newFilterQuery = null;
+            	if (f[0] != null && f[1] != null && f[2] != null) {
+            		newFilterQuery = SearchUtils.getSearchService()
                     .toFilterQuery(context, f[0], f[1], f[2])
                     .getFilterQuery();
+            	}
             if (newFilterQuery != null)
             {
                 queryArgs.addFilterQueries(newFilterQuery);

--- a/src/dspace-jspui/src/globus/webapp/search/discovery.jsp
+++ b/src/dspace-jspui/src/globus/webapp/search/discovery.jsp
@@ -114,10 +114,12 @@
 	    int idx = 1;
 	    for (String[] filter : appliedFilters)
 	    {
-	        httpFilters += "&amp;filter_field_"+idx+"="+URLEncoder.encode(filter[0],"UTF-8");
-	        httpFilters += "&amp;filter_type_"+idx+"="+URLEncoder.encode(filter[1],"UTF-8");
-	        httpFilters += "&amp;filter_value_"+idx+"="+URLEncoder.encode(filter[2],"UTF-8");
-	        idx++;
+	    	if (filter[0] != null && filter[1] != null && filter[2] != null) {
+	        	httpFilters += "&amp;filter_field_"+idx+"="+URLEncoder.encode(filter[0],"UTF-8");
+	        	httpFilters += "&amp;filter_type_"+idx+"="+URLEncoder.encode(filter[1],"UTF-8");
+	        	httpFilters += "&amp;filter_value_"+idx+"="+URLEncoder.encode(filter[2],"UTF-8");
+	        	idx++;
+	    	}
 	    }
 	}
     int rpp          = qArgs.getMaxResults();
@@ -267,7 +269,7 @@
 					{
 					    String fkey = "jsp.search.filter."+searchFilter.getIndexFieldName();
 					    %><option value="<%= searchFilter.getIndexFieldName() %>"<%
-					            if (filter[0].equals(searchFilter.getIndexFieldName()))
+					            if (filter[0] != null && filter[0].equals(searchFilter.getIndexFieldName()))
 					            {
 					                %> selected="selected"<%
 					                found = true;
@@ -313,13 +315,15 @@
 				int idx = 1;
 				for (String[] filter : appliedFilters)
 				{
-				    boolean found = false;
-				    %>
-				    <input type="hidden" id="filter_field_<%=idx %>" name="filter_field_<%=idx %>" value="<%= filter[0] %>" />
-					<input type="hidden" id="filter_type_<%=idx %>" name="filter_type_<%=idx %>" value="<%= filter[1] %>" />
-					<input type="hidden" id="filter_value_<%=idx %>" name="filter_value_<%=idx %>" value="<%= StringEscapeUtils.escapeHtml(filter[2]) %>" />
-					<%
-					idx++;
+					if (filter[0] != null && filter[1] != null && filter[2] != null) {
+				    	boolean found = false;
+				    	%>
+					    <input type="hidden" id="filter_field_<%=idx %>" name="filter_field_<%=idx %>" value="<%= filter[0] %>" />
+						<input type="hidden" id="filter_type_<%=idx %>" name="filter_type_<%=idx %>" value="<%= filter[1] %>" />
+						<input type="hidden" id="filter_value_<%=idx %>" name="filter_value_<%=idx %>" value="<%= StringEscapeUtils.escapeHtml(filter[2]) %>" />
+						<%
+						idx++;
+					}
 				}
 		} %>
 		<select id="filtername" name="filtername">
@@ -357,13 +361,15 @@
 				int idx = 1;
 				for (String[] filter : appliedFilters)
 				{
-				    boolean found = false;
-				    %>
-				    <input type="hidden" id="filter_field_<%=idx %>" name="filter_field_<%=idx %>" value="<%= filter[0] %>" />
-					<input type="hidden" id="filter_type_<%=idx %>" name="filter_type_<%=idx %>" value="<%= filter[1] %>" />
-					<input type="hidden" id="filter_value_<%=idx %>" name="filter_value_<%=idx %>" value="<%= StringEscapeUtils.escapeHtml(filter[2]) %>" />
-					<%
-					idx++;
+					if (filter[0] != null && filter[1] != null && filter[2] != null) {
+				    	boolean found = false;
+				    	%>
+				    	<input type="hidden" id="filter_field_<%=idx %>" name="filter_field_<%=idx %>" value="<%= filter[0] %>" />
+						<input type="hidden" id="filter_type_<%=idx %>" name="filter_type_<%=idx %>" value="<%= filter[1] %>" />
+						<input type="hidden" id="filter_value_<%=idx %>" name="filter_value_<%=idx %>" value="<%= StringEscapeUtils.escapeHtml(filter[2]) %>" />
+						<%
+						idx++;
+					}
 				}
 	} %>
            <label for="rpp"><fmt:message key="search.results.perpage"/></label>


### PR DESCRIPTION
It seems that perhaps the root cause is that DSpace assumes that all
query requests will be coming from clients that have a logged in
session and thus parts of the query building can get state from the
session. When non-session clients (like a web crawler or simple curl)
hit some of the query generation links, incomplete queries get built
and processing those queries results in errors.

This is an attempt to find various places where the query for
facets/filters is getting generated and put protective checks around
them. Hopefully, this gets them all.