### PR TITLE
Removing the identifiers service scope from globus-auth.cfg

### DIFF
--- a/src/dspace/config/modules/globus-auth.cfg
+++ b/src/dspace/config/modules/globus-auth.cfg
@@ -22,7 +22,7 @@ globus.client.base64.creds={{publish.globus_user_creds}}
 # Globus OAuth settings
 globus.client.id={{publish.globus_client.id}}
 globus.client.secret={{publish.globus_client.secret}}
-globus.auth.scope=urn:globus:auth:scope:auth.globus.org:view_identities urn:globus:auth:scope:nexus.api.globus.org:groups urn:globus:auth:scope:transfer.api.globus.org:all urn:globus:auth:scope:search.api.globus.org:all https://auth.globus.org/scopes/identifiers.globus.org/create_update
+globus.auth.scope=urn:globus:auth:scope:auth.globus.org:view_identities urn:globus:auth:scope:nexus.api.globus.org:groups urn:globus:auth:scope:transfer.api.globus.org:all urn:globus:auth:scope:search.api.globus.org:all
 globus.user.scope=741b8d79-53b6-4906-bddf-961d605b1fd7
 
 # Globus OAuth paths


### PR DESCRIPTION
This is useful only in our experimental identifiers setup, so not
needed in the general source repo. We'll configure as needed in our
own deployments.